### PR TITLE
Work around incorrect $GIT_DIR on Heroku

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -145,7 +145,7 @@ fi
 FLAGS=(-tags heroku)
 if test -n "$GO_GIT_DESCRIBE_SYMBOL"
 then
-    git_describe=$(git describe --tags --always)
+    git_describe=$(git --git-dir=/app/tmp/repo.git describe --tags --always)
     FLAGS=(${FLAGS[@]} -ldflags "-X $GO_GIT_DESCRIBE_SYMBOL $git_describe")
 fi
 


### PR DESCRIPTION
It appears that `$GIT_DIR="."` in the deploy environment, while we're not running in `/app/tmp/repo.git`, so any call to `git` fails.

This workaround hard-codes the absolute path, and frankly it seems like a bad idea but I could not come up with anything better, and our deploys are failing so this is kind of urgent.

@kr if you happen to know what happened to `GIT_DIR`, that could improve on this maybe. 