### PR TITLE
Fetch tags before running git describe

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -145,7 +145,7 @@ fi
 FLAGS=(-tags heroku)
 if test -n "$GO_GIT_DESCRIBE_SYMBOL"
 then
-    git fetch --tags
+    git fetch --tags || :
     git_describe=$(git describe --tags --always)
     FLAGS=(${FLAGS[@]} -ldflags "-X $GO_GIT_DESCRIBE_SYMBOL $git_describe")
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -145,6 +145,7 @@ fi
 FLAGS=(-tags heroku)
 if test -n "$GO_GIT_DESCRIBE_SYMBOL"
 then
+    git fetch --tags
     git_describe=$(git describe --tags --always)
     FLAGS=(${FLAGS[@]} -ldflags "-X $GO_GIT_DESCRIBE_SYMBOL $git_describe")
 fi


### PR DESCRIPTION
`git describe --tags --always` works much better if the tags are up to date, so try to run `git fetch --tags` first.