### PR TITLE
Behave better when GO_GIT_DESCRIBE_SYMBOL is unset

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -143,7 +143,7 @@ then
 fi
 
 FLAGS=(-tags heroku)
-if test -n "$GO_GIT_DESCRIBE_SYMBOL"
+if [ -z GO_GIT_DESCRIBE_SYMBOL ] && [ test -n "$GO_GIT_DESCRIBE_SYMBOL" ]
 then
     git_describe=$(git describe --tags --always)
     FLAGS=(${FLAGS[@]} -ldflags "-X $GO_GIT_DESCRIBE_SYMBOL $git_describe")


### PR DESCRIPTION
Necessary when working in an environment using `set -u`. Eg:
- a Cloud Foundry buildpack
- a multi-buildpack setting -u